### PR TITLE
Override $BUILDKITE_GIT_CLEAN_FLAGS to clean files ignored by Git

### DIFF
--- a/.buildkite/bin/upload-secrets
+++ b/.buildkite/bin/upload-secrets
@@ -78,6 +78,10 @@ EOT
   done
 }
 
+buildkite_flags() {
+  echo "export BUILDKITE_GIT_CLEAN_FLAGS=-fdqx"
+}
+
 echo "~~~ Uploading id_rsa"
 if [ -f ~/.ssh/deployer ]; then
   cat ~/.ssh/deployer | upload "id_rsa"
@@ -90,4 +94,5 @@ cat <<ENV | upload "env"
 $(ssh_config)
 $(docker_auth)
 $(configure_plain)
+$(buildkite_flags)
 ENV


### PR DESCRIPTION
This adds the `-x` flag to `git clean` as seen in the `bootstrap.sh`: https://github.com/buildkite/agent/blob/2-1-stable/templates/bootstrap.sh#L237

This matches everydayhero/configure#1458 but for the `elastic` cluster.
