### PR TITLE
Add locking around configure/plain-utils git operations

### DIFF
--- a/.buildkite/bin/upload-secrets
+++ b/.buildkite/bin/upload-secrets
@@ -73,11 +73,17 @@ configure_plain() {
 
   for repo in configure plain-utils; do
     cat <<EOT
-if [ -d "$code_dir/$repo" ] ; then
-  cd "$code_dir/$repo" && git pull
-else
-  cd "$code_dir" && git clone "git@github.com:everydayhero/${repo}.git"
-fi
+(
+  flock -e 200 || { echo "Could not lock $repo"; exit 10; }
+  if [[ ! -d "$code_dir/$repo" ]]; then
+    cd "$code_dir"
+    git clone "git@github.com:everydayhero/${repo}.git"
+  else
+    cd "$code_dir/$repo"
+    git fetch
+    git reset --hard origin/master
+  fi
+) 200>/tmp/$repo.lock
 export PATH="${code_dir}/${repo}/bin:\$PATH"
 EOT
   done


### PR DESCRIPTION
Concurrent `git pull`'s on the build node are not playing nice with shared git repo's.

To prevent a race condition, we spawn a subshell and use `flock` to get a lock on a file descriptor while we checkout/reset `configure` and `plain-utils`.

Also switch from `git pull` to `git fetch && git reset --hard origin/master` to mirror what the current "native" node does.