### PR TITLE
Commit var fallback to support Panoramix doc

### DIFF
--- a/.buildkite/bin/upload-secrets
+++ b/.buildkite/bin/upload-secrets
@@ -100,7 +100,7 @@ plain_pipeline_env() {
   echo 'export BRANCH="${BUILDKITE_BRANCH}"'
   echo 'export BUILD_NUMBER="${BUILDKITE_BUILD_NUMBER}"'
   echo 'export BUILD_URL="${BUILDKITE_BUILD_URL}"'
-  echo 'export COMMIT="${BUILDKITE_COMMIT}"'
+  echo 'export COMMIT="${COMMIT:-$BUILDKITE_COMMIT}"'
   echo 'export JOB_ID="${BUILDKITE_JOB_ID}"'
   echo 'export APP="${APP:-$(echo $BUILDKITE_REPO | sed -e '\'s/.*@.*:.*\\/\\\(.*\\\)\\.git/\\1/\'')}"'
 }


### PR DESCRIPTION
A recent [commit](https://github.com/everydayhero/buildkite-aws-stack/commit/e519f5446b45b7bcc49017b30db04e6b56739ac9) means that the Panoramix pipeline can no longer use the `COMMIT` variable to pull down a container tagged as `penguin` in it's tag staging step. I've made a small change to fallback to the Buildkite commit var if a commit var is not present. This will get our documentation being deployed again. I will also raise a ticket to see if we can improve the pipeline in Panoramix so that it no longer needs to override the commit var. The relevant portion of the panoramix pipeline:

```
  - name: ":hash:"
    command: "bin/buildkite bin/ci tag production"
    branches: "master release/*"
    env:
      COMMIT: penguin
    agents:
      queue: build
```