### PR TITLE
Remove SSH config from env

### DIFF
--- a/.buildkite/bin/upload-secrets
+++ b/.buildkite/bin/upload-secrets
@@ -22,41 +22,6 @@ upload() {
   fi
 }
 
-ssh_config() {
-  echo "mkdir -p ~/.ssh/cm"
-  echo "chmod 0700 ~/.ssh"
-  cat <<EOT
-cat <<SSH_CONFIG > ~/.ssh/config
-Host bastion-* *.plain.edh.ro
-  ForwardAgent yes
-  TCPKeepAlive yes
-  ServerAliveInterval 300
-  StrictHostKeyChecking no
-  ControlPath ~/.ssh/cm/%r@%h:%p
-  ControlMaster auto
-  ControlPersist 10m
-  User deployer
-
-Host bastion-production
-  Hostname bastion.everydayhero.io
-  Port 2020
-
-Host bastion-staging
-  Hostname bastion.everydayhero-staging.io
-  Port 2020
-
-Host production-*.plain.edh.ro
-  ProxyCommand ssh -q bastion-production 'ncat \\\`echo %h | cut -f 1-1 -d.\\\` %p'
-
-Host staging-*.plain.edh.ro
-  ProxyCommand ssh -q bastion-staging 'ncat \\\`echo %h | cut -f 1-1 -d.\\\` %p'
-
-Host github.com
-  StrictHostKeyChecking no
-SSH_CONFIG
-EOT
-}
-
 docker_auth() {
   if [ -n "$DOCKER_HUB_USER" ]; then
     echo "export DOCKER_LOGIN_USER=$DOCKER_HUB_USER"
@@ -107,7 +72,6 @@ plain_pipeline_env() {
 
 gen_env() {
 cat <<ENV | upload "$@"
-$(ssh_config)
 $(docker_auth)
 $(configure_plain)
 $(buildkite_flags)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ steps:
   - wait
 
   - name: ":terraform: Apply"
-    command: "buildkite-agent artifact download authorized-users . && cat authorized-users && .buildkite/bin/apply"
+    command: "buildkite-agent artifact download authorized-users . && .buildkite/bin/apply"
     branches: master
 
   - wait

--- a/main.tf
+++ b/main.tf
@@ -166,6 +166,10 @@ resource "aws_cloudformation_stack" "buildkite_queue" {
     Subnets                  = "${join(",", aws_subnet.private.*.id)}"
     AssociatePublicIpAddress = "false"
   }
+
+  lifecycle {
+    ignore_changes = ["parameters.BuildkiteAgentToken", "parameters.BuildkiteApiAccessToken"]
+  }
 }
 
 output "secrets_bucket" {


### PR DESCRIPTION
For some reason Terraform will inform the values have changes when they
have not and will trigger a CloudFormation update. This in itself
shouldn't be an issue but when CloudFormation reports there's no changes
to be made an error is shown when it shouldn't. This can be removed when
the issue is resolved in Terraform.