### PR TITLE
Run `plain-services-docker init` in the global environment hook

### DIFF
--- a/bin/generate-env
+++ b/bin/generate-env
@@ -83,6 +83,10 @@ plain_pipeline_env() {
   echo 'export APP="${APP:-$(echo $BUILDKITE_REPO | sed -e '\'s/.*@.*:.*\\/\\\(.*\\\)\\.git/\\1/\'')}"'
 }
 
+plain_services_docker_network() {
+  echo 'plain-services-docker init'
+}
+
 gen_env() {
 cat <<ENV
 $(ssh_config)
@@ -90,6 +94,7 @@ $(docker_auth)
 $(configure_plain)
 $(buildkite_flags)
 $(plain_pipeline_env)
+$(plain_services_docker_network)
 ENV
 }
 


### PR DESCRIPTION
Depends on everydayhero/plain-services-docker#11.

This will allow other pipelines to assume the presence of the shared `plain-services-docker` network, avoiding a failed build if the pipeline uses a Compose stack which depends on the shared network but doesn't create the shared network as part of a pipeline step.

See https://buildkite.com/everyday-hero/mothership/builds/933#81e81738-52b7-4357-857c-ce2d5cb1468b for how this manifests.