### PR TITLE
Add experimental spot fleet for default queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,9 +36,22 @@ steps:
     env:
       BUILDKITE_QUEUE: default
       INSTANCE_TYPE: m3.large
-      MIN_SIZE: 5
+      MIN_SIZE: 0
       MAX_SIZE: 20
       ROOT_VOLUME_SIZE: 100
+
+  - name: ":buildkite: Default Queue (Spot Fleet)"
+    command: "bin/stack default-spot"
+    branches: master
+    agents:
+      queue: buildkite
+    env:
+      BUILDKITE_QUEUE: default
+      INSTANCE_TYPE: m3.large
+      MIN_SIZE: 5
+      MAX_SIZE: 5
+      ROOT_VOLUME_SIZE: 100
+      SPOT_PRICE: 0.1340
 
   - name: ":buildkite: Build Queue"
     command: "bin/stack build"


### PR DESCRIPTION
The build account costs about $1,200/mo and we no longer have any reservations to cover the costs.

Experiment with using spot instances for the base instance count for the default queue. Max bid is set to the on-demand price for `m3.large`. The non-spot fleet ASG is now allowed to scale to 0 since the base load should be covered by the new group.

Looking to see:
- What eviction rates are like in practice when the spot > bid. From pricing history, it is unlikely we will see any
- How the autoscaling policies handle multiple ASG's with the same queue name
