### PR TITLE
Split spot fleet stack out

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,6 +52,7 @@ steps:
       MAX_SIZE: 5
       ROOT_VOLUME_SIZE: 100
       SPOT_PRICE: 0.1340
+      TEMPLATE: stack-spot.yml
 
   - name: ":buildkite: Build Queue"
     command: "bin/stack build"

--- a/stack-spot.yml
+++ b/stack-spot.yml
@@ -1,0 +1,154 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  Stack:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Sub https://s3.amazonaws.com/buildkite-aws-stack/${BuildkiteStackVersion}/aws-stack.json
+      Parameters:
+        AgentsPerInstance: !Ref AgentsPerInstance
+        AssociatePublicIpAddress: false
+        BuildkiteAgentRelease: !Ref BuildkiteAgentRelease
+        BuildkiteAgentToken: !Ref BuildkiteAgentToken
+        BuildkiteApiAccessToken: !Ref BuildkiteApiAccessToken
+        BuildkiteOrgSlug: !Ref BuildkiteOrgSlug
+        BuildkiteQueue: !Ref BuildkiteQueue
+        InstanceType: !Ref InstanceType
+        ManagedPolicyARN: !Ref ManagedPolicy
+        MaxSize: !Ref MaxSize
+        MinSize: !Ref MinSize
+        RootVolumeSize: !Ref RootVolumeSize
+        ScaleDownAdjustment: !Ref ScaleDownAdjustment
+        ScaleUpAdjustment: !Ref ScaleUpAdjustment
+        SpotPrice: !Ref SpotPrice
+        BootstrapScriptUrl:
+          Fn::Sub:
+            - 'https://s3.amazonaws.com/${SecretsBucket}/scripts/bootstrap'
+            - SecretsBucket:
+                Fn::ImportValue: !Sub ${BuildStack}-SecretsBucket
+        KeyName:
+          Fn::ImportValue: !Sub ${BuildStack}-KeyName
+        ArtifactsBucket:
+          Fn::ImportValue: !Sub ${BuildStack}-ArtifactsBucket
+        SecretsBucket:
+          Fn::ImportValue: !Sub ${BuildStack}-SecretsBucket
+        Subnets:
+          Fn::ImportValue: !Sub ${BuildStack}-Subnets
+        VpcId:
+          Fn::ImportValue: !Sub ${BuildStack}-VpcId
+
+  ManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: DefaultSpotManagedPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action: s3:PutObject
+            Resource:
+              Fn::Sub:
+                - 'arn:aws:s3:::${SecretsBucket}/terraform/*'
+                - SecretsBucket:
+                    Fn::ImportValue: !Sub ${BuildStack}-SecretsBucket
+            Condition:
+              StringEquals:
+                s3:x-amz-server-side-encryption: [ 'AES256', 'true' ]
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Ref AccountRoles
+
+Parameters:
+  BuildStack:
+    Type: String
+    MinLength: 1
+    Description: The CloudFormation stack to import VPC and Subnets from
+
+  BuildkiteAgentToken:
+    Type: String
+    Description: Buildkite agent token
+    NoEcho: true
+    MinLength: 1
+
+  BuildkiteApiAccessToken:
+    Type: String
+    Description: Buildkite API access token with read_pipelines, read_builds and read_agents (required for metrics)
+    NoEcho: true
+    MinLength: 1
+
+  BuildkiteOrgSlug:
+    Type: String
+    Description: Buildkite organization slug
+    MinLength: 1
+
+  BuildkiteQueue:
+    Type: String
+    Description: 'Queue name that agents will use, targeted in pipeline steps using "queue={value}"'
+    Default: default
+    MinLength: 1
+
+  BuildkiteAgentRelease:
+    Type: String
+    Default: stable
+    AllowedValues:
+      - stable
+      - beta
+      - edge
+
+  BuildkiteStackVersion:
+    Type: String
+    Description: The version of the Buildkite elastic stack for AWS
+    Default: latest
+    MinLength: 1
+
+  InstanceType:
+    Type: String
+    Description: Instance type
+    Default: t2.nano
+    MinLength: 1
+
+  AgentsPerInstance:
+    Type: Number
+    Description: Number of Buildkite agents to run on each instance
+    Default: 1
+    MinValue: 1
+
+  MaxSize:
+    Type: Number
+    Description: Maximum number of instances for default queue
+    Default: 1
+    MinValue: 1
+
+  MinSize:
+    Type: Number
+    Description: Minimum number of instances for default queue
+    Default: 0
+    MinValue: 0
+
+  ScaleDownAdjustment:
+    Type: Number
+    Description: Number of instances to remove on scale down events (UnfinishedJobs == 0 for 30 mins)
+    Default: -1
+    MaxValue: 0
+
+  ScaleUpAdjustment:
+    Type: Number
+    Description: Number of instances to add on scale up events (ScheduledJobsCount > 0 for 1 min)
+    Default: 5
+    MinValue: 0
+
+  SpotPrice:
+    Description: Spot bid price to use for the instances. 0 means normal (non-spot) instances
+    Type: String
+    Default: 0
+
+  RootVolumeSize:
+    Type: Number
+    Description: Size of each instance's root EBS volume (in GB)
+    Default: 10
+    MinValue: 10
+
+  AccountRoles:
+    Type: 'CommaDelimitedList'
+    Description: A comma separated list roles that can be assumed as
+    Default: ''

--- a/stack.yml
+++ b/stack.yml
@@ -20,6 +20,7 @@ Resources:
         RootVolumeSize: !Ref RootVolumeSize
         ScaleDownAdjustment: !Ref ScaleDownAdjustment
         ScaleUpAdjustment: !Ref ScaleUpAdjustment
+        SpotPrice: !Ref SpotPrice
         BootstrapScriptUrl:
           Fn::Sub:
             - 'https://s3.amazonaws.com/${SecretsBucket}/scripts/bootstrap'
@@ -138,6 +139,11 @@ Parameters:
     Description: Number of instances to add on scale up events (ScheduledJobsCount > 0 for 1 min)
     Default: 5
     MinValue: 0
+
+  SpotPrice:
+    Description: Spot bid price to use for the instances. 0 means normal (non-spot) instances
+    Type: String
+    Default: 0
 
   RootVolumeSize:
     Type: Number


### PR DESCRIPTION
Resolves an issue with the managed policy name collision and means we don't have to add extra conditional logic