### PR TITLE
Reduce amount of EBS used by default queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       INSTANCE_TYPE: m3.large
       MIN_SIZE: 3
       MAX_SIZE: 20
-      ROOT_VOLUME_SIZE: 100
+      ROOT_VOLUME_SIZE: 60
       SPOT_PRICE: "0.1330"
 
   - name: ":buildkite: Build Queue"


### PR DESCRIPTION
Apart from instance costs, EBS is the next most expensive. 
Shaves 40GB off nodes that are recycled pretty often